### PR TITLE
Install missing symlinks, do not install test twice

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,9 @@ rpmatch = cc.find_library('rpmatch', required : false)
 # Header files for libcompat
 inc = include_directories('include')
 
+# Symlink installation script
+install_link = meson.current_source_dir() / 'utils/install-link.sh'
+
 # Include all of the relevant subdirectories
 subdir('compat')
 subdir('src')

--- a/src/ln/meson.build
+++ b/src/ln/meson.build
@@ -7,3 +7,5 @@ ln_prog = executable(
 
 install_man('ln.1')
 install_man('symlink.7')
+
+meson.add_install_script(install_link, 'ln', 'link', get_option('bindir'))

--- a/src/rm/meson.build
+++ b/src/rm/meson.build
@@ -8,3 +8,5 @@ rm_prog = executable(
 )
 
 install_man('rm.1')
+
+meson.add_install_script(install_link, 'rm', 'unlink', get_option('bindir'))

--- a/src/stat/meson.build
+++ b/src/stat/meson.build
@@ -7,3 +7,5 @@ stat_prog = executable(
 )
 
 install_man('stat.1')
+
+meson.add_install_script(install_link, 'stat', 'readlink', get_option('bindir'))

--- a/src/test/install.sh
+++ b/src/test/install.sh
@@ -2,5 +2,6 @@
 
 BINDIR="${1}"
 
-mkdir -p "${DESTDIR}/${MESON_INSTALL_PREFIX}${BINDIR}"
-install -D -m 0755 ${MESON_BUILD_ROOT}/src/test/xtest "${DESTDIR}/${MESON_INSTALL_PREFIX}${BINDIR}"/test
+mkdir -p "${DESTDIR}/${MESON_INSTALL_PREFIX}/${BINDIR}"
+install -D -m 0755 ${MESON_BUILD_ROOT}/src/test/xtest "${DESTDIR}/${MESON_INSTALL_PREFIX}/${BINDIR}"/test
+ln -sf test "${DESTDIR}/${MESON_INSTALL_PREFIX}/${BINDIR}/["

--- a/src/test/meson.build
+++ b/src/test/meson.build
@@ -1,8 +1,7 @@
 test_prog = executable(
     'xtest',
     [ 'test.c' ],
-    include_directories : inc,
-    install : true,
+    include_directories : inc
 )
 
 meson.add_install_script('install.sh', get_option('bindir'))

--- a/utils/install-link.sh
+++ b/utils/install-link.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+ORIGIN="${1}"
+TARGET="${2}"
+BINDIR="${3}"
+
+mkdir -p "${DESTDIR}/${MESON_INSTALL_PREFIX}/${BINDIR}"
+ln -sf "${ORIGIN}" "${DESTDIR}/${MESON_INSTALL_PREFIX}/${BINDIR}/${TARGET}"


### PR DESCRIPTION
Also fix `test`'s install path missing a slash (which would result in it being installed in e.g. `/usr/localbin` instead of in
`/usr/local/bin`)