### PR TITLE
env: fix treatment of args

### DIFF
--- a/DIFFERENCES
+++ b/DIFFERENCES
@@ -825,11 +825,15 @@ howmany()
 ---------
 This macro is available in <sys/param.h> on Linux.
 
-
-optreset
+getopt()
 --------
-getopt() on OpenBSD uses an optreset variable.  glibc does not have
-this on Linux, so uses of it are removed from this port.
+
+The semantics of a dash at the beginning of optstring differ between
+BSD and GNU variants. On BSD, it simply means to permit the literal
+option -, while GNU style implementations have it result in every
+non-option parameter being treated as an option parameter with the
+value 1. Therefore, this is removed in the ports and reimplemented
+in other ways.
 
 
 MACHINE_ARCH

--- a/patches/src/env/env.c.patch
+++ b/patches/src/env/env.c.patch
@@ -1,6 +1,6 @@
 --- env/env.c.orig	2021-04-09 02:24:12.000000000 +0200
 +++ env/env.c	2021-06-12 06:22:35.052183107 +0200
-@@ -42,13 +42,11 @@ static char sccsid[] = "@(#)env.c	8.3 (B
+@@ -42,13 +42,11 @@ static char sccsid[] = "@(#)env.c	8.3 (Berkeley) 4/2/94";
  #endif
  
  #include <sys/cdefs.h>
@@ -36,7 +36,7 @@
  	want_clear = 0;
  	term = '\n';
 -	while ((ch = getopt(argc, argv, "-0iL:P:S:U:u:v")) != -1)
-+	while ((ch = getopt(argc, argv, "-0iP:S:u:v")) != -1)
++	while ((ch = getopt(argc, argv, "0iP:S:u:v")) != -1)
  		switch(ch) {
  		case '-':
  		case 'i':
@@ -53,7 +53,18 @@
  		case 'P':
  			altpath = strdup(optarg);
  			break;
-@@ -141,9 +128,6 @@ main(int argc, char **argv)
+@@ -134,6 +121,10 @@ main(int argc, char **argv)
+ 		default:
+ 			usage();
+ 		}
++	if (optind < argc && !strcmp(argv[optind], "-")) {
++		want_clear = 1;
++		++argv; /* skip the initial - during later scan */
++	}
+ 	if (want_clear) {
+ 		environ = cleanenv;
+ 		cleanenv[0] = NULL;
+@@ -141,9 +132,6 @@ main(int argc, char **argv)
  			fprintf(stderr, "#env clearing environ\n");
  	}
  	if (login_name != NULL) {
@@ -63,7 +74,7 @@
  		if (*login_name != '\0' && strcmp(login_name, "-") != 0) {
  			pw = getpwnam(login_name);
  			if (pw == NULL) {
-@@ -156,38 +140,8 @@ main(int argc, char **argv)
+@@ -156,38 +144,8 @@ main(int argc, char **argv)
  			if (pw == NULL)
  				errx(EXIT_FAILURE, "no such user: %s", login_name);
  		}

--- a/src/env/env.c
+++ b/src/env/env.c
@@ -85,7 +85,7 @@ main(int argc, char **argv)
 	pw = NULL;
 	want_clear = 0;
 	term = '\n';
-	while ((ch = getopt(argc, argv, "-0iP:S:u:v")) != -1)
+	while ((ch = getopt(argc, argv, "0iP:S:u:v")) != -1)
 		switch(ch) {
 		case '-':
 		case 'i':
@@ -121,6 +121,10 @@ main(int argc, char **argv)
 		default:
 			usage();
 		}
+	if (optind < argc && !strcmp(argv[optind], "-")) {
+		want_clear = 1;
+		++argv; /* skip the initial - during later scan */
+	}
 	if (want_clear) {
 		environ = cleanenv;
 		cleanenv[0] = NULL;


### PR DESCRIPTION
the option string would previously begin with -, which behaves differently with different implementation of `getopt(3)` - on GNU
as well as musl, it makes nonoption argv's get treated as options with value 1, while on BSD it permits literal '-' to be used as
an option.

Since we don't have any way to emulate the BSD behavior, and FreeBSD itself discourages use of it (it being there for backwards
compat only), just patch it out entirely and follow the GNU env semantics of '-' having special behavior when it is the first non-option argument.