### PR TITLE
Fix build of stty(1) on musl + fix baud/speed distinction

### DIFF
--- a/patches/src/stty/cchar.c.patch
+++ b/patches/src/stty/cchar.c.patch
@@ -1,6 +1,12 @@
---- stty/cchar.c.orig	2021-04-27 23:52:35.000000000 -0400
-+++ stty/cchar.c	2021-06-29 14:08:25.546012223 -0400
-@@ -41,6 +41,8 @@ __FBSDID("$FreeBSD$");
+--- stty/cchar.c.orig	2021-06-30 17:30:31.690723908 +0200
++++ stty/cchar.c	2021-06-30 17:07:18.070580099 +0200
+@@ -36,11 +36,14 @@ static char sccsid[] = "@(#)cchar.c	8.5
+ __FBSDID("$FreeBSD$");
+ 
+ #include <sys/types.h>
++#include <sys/ttydefaults.h>
+ 
+ #include <err.h>
  #include <limits.h>
  #include <stdlib.h>
  #include <string.h>
@@ -9,7 +15,7 @@
  
  #include "stty.h"
  #include "extern.h"
-@@ -56,12 +58,11 @@ static int c_cchar(const void *, const v
+@@ -56,12 +59,11 @@ static int c_cchar(const void *, const v
   */
  struct cchar cchars1[] = {
  	{ "discard",	VDISCARD, 	CDISCARD },
@@ -23,7 +29,7 @@
  	{ "intr",	VINTR,		CINTR },
  	{ "kill",	VKILL,		CKILL },
  	{ "lnext",	VLNEXT,		CLNEXT },
-@@ -69,7 +70,7 @@ struct cchar cchars1[] = {
+@@ -69,7 +71,7 @@ struct cchar cchars1[] = {
  	{ "quit",	VQUIT,		CQUIT },
  	{ "reprint",	VREPRINT, 	CREPRINT },
  	{ "start",	VSTART,		CSTART },

--- a/patches/src/stty/extern.h.patch
+++ b/patches/src/stty/extern.h.patch
@@ -1,0 +1,10 @@
+--- stty/extern.h.orig	2021-06-30 21:39:51.939005739 +0200
++++ stty/extern.h	2021-06-30 21:44:43.597680911 +0200
+@@ -42,4 +42,7 @@ void	optlist(void);
+ void	print(struct termios *, struct winsize *, int, enum FMT);
+ void	usage(void) __dead2;
+ 
++int get_baud(speed_t s);
++speed_t get_speed(unsigned long b);
++
+ extern struct cchar cchars1[], cchars2[];

--- a/patches/src/stty/gfmt.c.patch
+++ b/patches/src/stty/gfmt.c.patch
@@ -1,5 +1,5 @@
 --- stty/gfmt.c.orig	2021-06-30 17:30:57.488135019 +0200
-+++ stty/gfmt.c	2021-06-30 17:00:32.011330012 +0200
++++ stty/gfmt.c	2021-06-30 22:01:19.333564627 +0200
 @@ -40,7 +40,9 @@ __FBSDID("$FreeBSD$");
  #include <err.h>
  #include <stdio.h>
@@ -19,6 +19,15 @@
  {
  	struct cchar *cp;
  
+@@ -67,7 +69,7 @@ gprint(struct termios *tp, struct winsiz
+ 	for (cp = cchars1; cp->name; ++cp)
+ 		(void)printf("%s=%x:", cp->name, tp->c_cc[cp->sub]);
+ 	(void)printf("ispeed=%lu:ospeed=%lu\n",
+-	    (u_long)cfgetispeed(tp), (u_long)cfgetospeed(tp));
++	    (u_long)get_baud(cfgetispeed(tp)), (u_long)get_baud(cfgetospeed(tp)));
+ }
+ 
+ void
 @@ -99,7 +101,7 @@ gread(struct termios *tp, char *s)
  		}
  		if (CHK("ispeed")) {

--- a/patches/src/stty/gfmt.c.patch
+++ b/patches/src/stty/gfmt.c.patch
@@ -1,5 +1,5 @@
---- stty/gfmt.c.orig	2021-06-12 09:32:06.000000000 -0400
-+++ stty/gfmt.c	2021-06-30 09:47:26.551198749 -0400
+--- stty/gfmt.c.orig	2021-06-30 17:30:57.488135019 +0200
++++ stty/gfmt.c	2021-06-30 17:00:32.011330012 +0200
 @@ -40,7 +40,9 @@ __FBSDID("$FreeBSD$");
  #include <err.h>
  #include <stdio.h>
@@ -10,3 +10,30 @@
  
  #include "stty.h"
  #include "extern.h"
+@@ -57,7 +59,7 @@ gerr(const char *s)
+ }
+ 
+ void
+-gprint(struct termios *tp, struct winsize *wp __unused, int ldisc __unused)
++gprint(struct termios *tp, struct winsize *wp __attribute__((unused)), int ldisc __attribute__((unused)))
+ {
+ 	struct cchar *cp;
+ 
+@@ -99,7 +101,7 @@ gread(struct termios *tp, char *s)
+ 		}
+ 		if (CHK("ispeed")) {
+ 			tmp = strtoul(ep, NULL, 10);
+-			tp->c_ispeed = tmp;
++			cfsetispeed(tp, tmp);
+ 			continue;
+ 		}
+ 		if (CHK("lflag")) {
+@@ -112,7 +114,7 @@ gread(struct termios *tp, char *s)
+ 		}
+ 		if (CHK("ospeed")) {
+ 			tmp = strtoul(ep, NULL, 10);
+-			tp->c_ospeed = tmp;
++			cfsetospeed(tp, tmp);
+ 			continue;
+ 		}
+ 		for (cp = cchars1; cp->name != NULL; ++cp)

--- a/patches/src/stty/key.c.patch
+++ b/patches/src/stty/key.c.patch
@@ -1,17 +1,10 @@
---- stty/key.c.orig	2021-04-27 23:52:35.000000000 -0400
-+++ stty/key.c	2021-06-30 09:50:00.446889340 -0400
-@@ -27,6 +27,9 @@
-  * SUCH DAMAGE.
-  */
+--- stty/key.c.orig	2021-06-30 17:31:23.717502782 +0200
++++ stty/key.c	2021-06-30 17:28:43.509580383 +0200
+@@ -36,11 +36,15 @@ static char sccsid[] = "@(#)key.c	8.3 (B
+ __FBSDID("$FreeBSD$");
  
-+/* necessary to get 'ttydefchars' */
-+#define TTYDEFCHARS
-+
- #ifndef lint
- #if 0
- static char sccsid[] = "@(#)key.c	8.3 (Berkeley) 4/2/94";
-@@ -38,9 +41,12 @@ __FBSDID("$FreeBSD$");
  #include <sys/types.h>
++#include <sys/ttydefaults.h>
  
  #include <err.h>
 +#include <errno.h>
@@ -23,7 +16,7 @@
  
  #include "stty.h"
  #include "extern.h"
-@@ -191,13 +197,23 @@ f_everything(struct info *ip)
+@@ -191,13 +195,23 @@ f_everything(struct info *ip)
  void
  f_extproc(struct info *ip)
  {
@@ -51,7 +44,7 @@
  	}
  }
  
-@@ -258,11 +274,17 @@ f_sane(struct info *ip)
+@@ -258,11 +272,16 @@ f_sane(struct info *ip)
  {
  	struct termios def;
  
@@ -60,9 +53,8 @@
 +	def.c_iflag = TTYDEF_IFLAG;
 +	def.c_lflag = TTYDEF_LFLAG;
 +	def.c_oflag = TTYDEF_OFLAG;
-+	def.c_ispeed = TTYDEF_SPEED;
-+	def.c_ospeed = TTYDEF_SPEED;
-+	memcpy(def.c_cc, ttydefchars, sizeof ttydefchars);
++	cfsetispeed(&def, TTYDEF_SPEED);
++	cfsetospeed(&def, TTYDEF_SPEED);
  	ip->t.c_cflag = def.c_cflag | (ip->t.c_cflag & CLOCAL);
  	ip->t.c_iflag = def.c_iflag;
  	/* preserve user-preference flags in lflag */
@@ -71,7 +63,7 @@
  	ip->t.c_lflag = def.c_lflag | (ip->t.c_lflag & LKEEP);
  	ip->t.c_oflag = def.c_oflag;
  	ip->set = 1;
-@@ -287,7 +309,7 @@ f_tty(struct info *ip)
+@@ -287,7 +306,7 @@ f_tty(struct info *ip)
  {
  	int tmp;
  

--- a/patches/src/stty/key.c.patch
+++ b/patches/src/stty/key.c.patch
@@ -1,5 +1,5 @@
 --- stty/key.c.orig	2021-06-30 17:31:23.717502782 +0200
-+++ stty/key.c	2021-06-30 17:28:43.509580383 +0200
++++ stty/key.c	2021-06-30 22:00:27.838742175 +0200
 @@ -36,11 +36,15 @@ static char sccsid[] = "@(#)key.c	8.3 (B
  __FBSDID("$FreeBSD$");
  
@@ -63,6 +63,15 @@
  	ip->t.c_lflag = def.c_lflag | (ip->t.c_lflag & LKEEP);
  	ip->t.c_oflag = def.c_oflag;
  	ip->set = 1;
+@@ -279,7 +298,7 @@ void
+ f_speed(struct info *ip)
+ {
+ 
+-	(void)printf("%lu\n", (u_long)cfgetospeed(&ip->t));
++	(void)printf("%lu\n", (u_long)get_baud(cfgetospeed(&ip->t)));
+ }
+ 
+ void
 @@ -287,7 +306,7 @@ f_tty(struct info *ip)
  {
  	int tmp;

--- a/patches/src/stty/print.c.patch
+++ b/patches/src/stty/print.c.patch
@@ -1,5 +1,5 @@
---- stty/print.c.orig	2021-04-27 23:52:35.000000000 -0400
-+++ stty/print.c	2021-06-29 14:08:13.530039012 -0400
+--- stty/print.c.orig	2021-06-30 21:11:23.806749931 +0200
++++ stty/print.c	2021-06-30 21:58:23.795214134 +0200
 @@ -40,6 +40,8 @@ __FBSDID("$FreeBSD$");
  #include <stddef.h>
  #include <stdio.h>
@@ -25,6 +25,18 @@
  			cnt += printf("ppp disc; ");
  			break;
  		default:
+@@ -79,9 +81,9 @@ print(struct termios *tp, struct winsize
+ 	ospeed = cfgetospeed(tp);
+ 	if (ispeed != ospeed)
+ 		cnt +=
+-		    printf("ispeed %d baud; ospeed %d baud;", ispeed, ospeed);
++		    printf("ispeed %d baud; ospeed %d baud;", get_baud(ispeed), get_baud(ospeed));
+ 	else
+-		cnt += printf("speed %d baud;", ispeed);
++		cnt += printf("speed %d baud;", get_baud(ispeed));
+ 	if (fmt >= BSD)
+ 		cnt += printf(" %d rows; %d columns;", wp->ws_row, wp->ws_col);
+ 	if (cnt)
 @@ -105,12 +107,11 @@ print(struct termios *tp, struct winsize
  	put("-echonl", ECHONL, 0);
  	put("-echoctl", ECHOCTL, 0);

--- a/patches/src/stty/util.c.patch
+++ b/patches/src/stty/util.c.patch
@@ -1,5 +1,5 @@
---- stty/util.c.orig	2021-04-27 23:52:35.000000000 -0400
-+++ stty/util.c	2021-06-30 09:48:02.992125484 -0400
+--- stty/util.c.orig	2021-06-30 21:41:46.867450256 +0200
++++ stty/util.c	2021-06-30 21:44:59.864045409 +0200
 @@ -40,6 +40,7 @@ __FBSDID("$FreeBSD$");
  
  #include <err.h>
@@ -8,3 +8,28 @@
  
  #include "stty.h"
  #include "extern.h"
+@@ -60,3 +61,24 @@ checkredirect(void)
+ 	    (sb1.st_rdev != sb2.st_rdev))
+ warnx("stdout appears redirected, but stdin is the control descriptor");
+ }
++
++static const int baudlist[] = {
++	0, 50, 75, 110, 134, 150, 200, 300, 600, 1200, 1800, 2400, 4800, 9600,
++	19200, 38400, 57600, 115200, 230400, 460800, 500000, 576000, 921600,
++	1000000, 1152000, 1500000, 2000000, 2500000, 3000000, 3500000, 4000000,
++};
++
++int get_baud(speed_t s) {
++	if (s & CBAUDEX)
++		s = (s & ~CBAUDEX) + 16;
++	return baudlist[s];
++}
++
++speed_t get_speed(unsigned long b) {
++	for (size_t i = 0; i < (sizeof(baudlist) / sizeof(int)); ++i) {
++		if ((unsigned long)baudlist[i] != b)
++			continue;
++		return i;
++	}
++	errx(1, "unknown speed for baud %lu", b);
++}

--- a/src/stty/cchar.c
+++ b/src/stty/cchar.c
@@ -36,6 +36,7 @@ static char sccsid[] = "@(#)cchar.c	8.5 (Berkeley) 4/2/94";
 __FBSDID("$FreeBSD$");
 
 #include <sys/types.h>
+#include <sys/ttydefaults.h>
 
 #include <err.h>
 #include <limits.h>

--- a/src/stty/extern.h
+++ b/src/stty/extern.h
@@ -42,4 +42,7 @@ void	optlist(void);
 void	print(struct termios *, struct winsize *, int, enum FMT);
 void	usage(void) __dead2;
 
+int get_baud(speed_t s);
+speed_t get_speed(unsigned long b);
+
 extern struct cchar cchars1[], cchars2[];

--- a/src/stty/gfmt.c
+++ b/src/stty/gfmt.c
@@ -69,7 +69,7 @@ gprint(struct termios *tp, struct winsize *wp __attribute__((unused)), int ldisc
 	for (cp = cchars1; cp->name; ++cp)
 		(void)printf("%s=%x:", cp->name, tp->c_cc[cp->sub]);
 	(void)printf("ispeed=%lu:ospeed=%lu\n",
-	    (u_long)cfgetispeed(tp), (u_long)cfgetospeed(tp));
+	    (u_long)get_baud(cfgetispeed(tp)), (u_long)get_baud(cfgetospeed(tp)));
 }
 
 void

--- a/src/stty/gfmt.c
+++ b/src/stty/gfmt.c
@@ -101,7 +101,7 @@ gread(struct termios *tp, char *s)
 		}
 		if (CHK("ispeed")) {
 			tmp = strtoul(ep, NULL, 10);
-			tp->c_ispeed = tmp;
+			cfsetispeed(tp, tmp);
 			continue;
 		}
 		if (CHK("lflag")) {
@@ -114,7 +114,7 @@ gread(struct termios *tp, char *s)
 		}
 		if (CHK("ospeed")) {
 			tmp = strtoul(ep, NULL, 10);
-			tp->c_ospeed = tmp;
+			cfsetospeed(tp, tmp);
 			continue;
 		}
 		for (cp = cchars1; cp->name != NULL; ++cp)

--- a/src/stty/key.c
+++ b/src/stty/key.c
@@ -27,9 +27,6 @@
  * SUCH DAMAGE.
  */
 
-/* necessary to get 'ttydefchars' */
-#define TTYDEFCHARS
-
 #ifndef lint
 #if 0
 static char sccsid[] = "@(#)key.c	8.3 (Berkeley) 4/2/94";
@@ -39,6 +36,7 @@ static char sccsid[] = "@(#)key.c	8.3 (Berkeley) 4/2/94";
 __FBSDID("$FreeBSD$");
 
 #include <sys/types.h>
+#include <sys/ttydefaults.h>
 
 #include <err.h>
 #include <errno.h>
@@ -278,9 +276,8 @@ f_sane(struct info *ip)
 	def.c_iflag = TTYDEF_IFLAG;
 	def.c_lflag = TTYDEF_LFLAG;
 	def.c_oflag = TTYDEF_OFLAG;
-	def.c_ispeed = TTYDEF_SPEED;
-	def.c_ospeed = TTYDEF_SPEED;
-	memcpy(def.c_cc, ttydefchars, sizeof ttydefchars);
+	cfsetispeed(&def, TTYDEF_SPEED);
+	cfsetospeed(&def, TTYDEF_SPEED);
 	ip->t.c_cflag = def.c_cflag | (ip->t.c_cflag & CLOCAL);
 	ip->t.c_iflag = def.c_iflag;
 	/* preserve user-preference flags in lflag */

--- a/src/stty/key.c
+++ b/src/stty/key.c
@@ -298,7 +298,7 @@ void
 f_speed(struct info *ip)
 {
 
-	(void)printf("%lu\n", (u_long)cfgetospeed(&ip->t));
+	(void)printf("%lu\n", (u_long)get_baud(cfgetospeed(&ip->t)));
 }
 
 void

--- a/src/stty/print.c
+++ b/src/stty/print.c
@@ -81,9 +81,9 @@ print(struct termios *tp, struct winsize *wp, int ldisc, enum FMT fmt)
 	ospeed = cfgetospeed(tp);
 	if (ispeed != ospeed)
 		cnt +=
-		    printf("ispeed %d baud; ospeed %d baud;", ispeed, ospeed);
+		    printf("ispeed %d baud; ospeed %d baud;", get_baud(ispeed), get_baud(ospeed));
 	else
-		cnt += printf("speed %d baud;", ispeed);
+		cnt += printf("speed %d baud;", get_baud(ispeed));
 	if (fmt >= BSD)
 		cnt += printf(" %d rows; %d columns;", wp->ws_row, wp->ws_col);
 	if (cnt)

--- a/src/stty/stty.c
+++ b/src/stty/stty.c
@@ -131,10 +131,13 @@ args:	argc -= optind;
 
 		if (isdigit(**argv)) {
 			speed_t speed;
-			speed = strtoul(*argv, NULL, 10);
-			if (errno == ERANGE || errno == EINVAL) {
+			unsigned long baud;
+			char *errstr;
+			baud = strtoul(*argv, &errstr, 10);
+			if (*errstr) {
 				err(1, "speed");
 			}
+			speed = get_speed(baud);
 			cfsetospeed(&i.t, speed);
 			cfsetispeed(&i.t, speed);
 			i.set = 1;

--- a/src/stty/util.c
+++ b/src/stty/util.c
@@ -61,3 +61,24 @@ checkredirect(void)
 	    (sb1.st_rdev != sb2.st_rdev))
 warnx("stdout appears redirected, but stdin is the control descriptor");
 }
+
+static const int baudlist[] = {
+	0, 50, 75, 110, 134, 150, 200, 300, 600, 1200, 1800, 2400, 4800, 9600,
+	19200, 38400, 57600, 115200, 230400, 460800, 500000, 576000, 921600,
+	1000000, 1152000, 1500000, 2000000, 2500000, 3000000, 3500000, 4000000,
+};
+
+int get_baud(speed_t s) {
+	if (s & CBAUDEX)
+		s = (s & ~CBAUDEX) + 16;
+	return baudlist[s];
+}
+
+speed_t get_speed(unsigned long b) {
+	for (size_t i = 0; i < (sizeof(baudlist) / sizeof(int)); ++i) {
+		if ((unsigned long)baudlist[i] != b)
+			continue;
+		return i;
+	}
+	errx(1, "unknown speed for baud %lu", b);
+}


### PR DESCRIPTION
Turns out `ttydefchars` is just not needed at all because `c_cc` is never copied into `struct info` in that function (which is good, because it does not exist on musl)