### PR TITLE
dc(1): fix build with openssl 3.x

### DIFF
--- a/patches/src/dc/bcode.c.patch
+++ b/patches/src/dc/bcode.c.patch
@@ -1,0 +1,29 @@
+--- dc/bcode.c.orig	2022-01-05 03:24:49.584603473 +0100
++++ dc/bcode.c	2022-01-05 03:27:46.355291510 +0100
+@@ -378,7 +378,7 @@ split_number(const struct number *n, BIG
+ 	bn_checkp(BN_copy(i, n->number));
+ 
+ 	if (n->scale == 0 && f != NULL)
+-		bn_check(BN_zero(f));
++		BN_zero(f);
+ 	else if (n->scale < sizeof(factors)/sizeof(factors[0])) {
+ 		rem = BN_div_word(i, factors[n->scale]);
+ 		if (f != NULL)
+@@ -811,7 +811,7 @@ load(void)
+ 		v = stack_tos(&bmachine.reg[idx]);
+ 		if (v == NULL) {
+ 			n = new_number();
+-			bn_check(BN_zero(n->number));
++			BN_zero(n->number);
+ 			push_number(n);
+ 		} else
+ 			push(stack_dup_value(v, &copy));
+@@ -896,7 +896,7 @@ load_array(void)
+ 			v = frame_retrieve(stack, idx);
+ 			if (v == NULL || v->type == BCODE_NONE) {
+ 				n = new_number();
+-				bn_check(BN_zero(n->number));
++				BN_zero(n->number);
+ 				push_number(n);
+ 			}
+ 			else

--- a/patches/src/dc/inout.c.patch
+++ b/patches/src/dc/inout.c.patch
@@ -1,5 +1,5 @@
 --- dc/inout.c.orig	2021-04-09 02:24:12.000000000 +0200
-+++ dc/inout.c	2021-06-12 06:22:35.020186271 +0200
++++ dc/inout.c	2022-01-05 03:25:41.711498447 +0100
 @@ -177,7 +177,8 @@ printwrap(FILE *f, const char *p)
  	char buf[12];
  
@@ -10,3 +10,23 @@
  	while (*q)
  		putcharwrap(f, *q++);
  }
+@@ -192,7 +193,7 @@ readnumber(struct source *src, u_int bas
+ 	bool dot = false, sign = false;
+ 
+ 	n = new_number();
+-	bn_check(BN_zero(n->number));
++	BN_zero(n->number);
+ 
+ 	while ((ch = (*src->vtable->readchar)(src)) != EOF) {
+ 
+@@ -230,8 +231,8 @@ readnumber(struct source *src, u_int bas
+ 		base_n = BN_new();
+ 		exponent = BN_new();
+ 		divisor = new_number();
+-		bn_check(BN_zero(base_n));
+-		bn_check(BN_zero(exponent));
++		BN_zero(base_n);
++		BN_zero(exponent);
+ 
+ 		bn_check(BN_add_word(base_n, base));
+ 		bn_check(BN_add_word(exponent, iscale));

--- a/src/dc/bcode.c
+++ b/src/dc/bcode.c
@@ -378,7 +378,7 @@ split_number(const struct number *n, BIGNUM *i, BIGNUM *f)
 	bn_checkp(BN_copy(i, n->number));
 
 	if (n->scale == 0 && f != NULL)
-		bn_check(BN_zero(f));
+		BN_zero(f);
 	else if (n->scale < sizeof(factors)/sizeof(factors[0])) {
 		rem = BN_div_word(i, factors[n->scale]);
 		if (f != NULL)
@@ -811,7 +811,7 @@ load(void)
 		v = stack_tos(&bmachine.reg[idx]);
 		if (v == NULL) {
 			n = new_number();
-			bn_check(BN_zero(n->number));
+			BN_zero(n->number);
 			push_number(n);
 		} else
 			push(stack_dup_value(v, &copy));
@@ -896,7 +896,7 @@ load_array(void)
 			v = frame_retrieve(stack, idx);
 			if (v == NULL || v->type == BCODE_NONE) {
 				n = new_number();
-				bn_check(BN_zero(n->number));
+				BN_zero(n->number);
 				push_number(n);
 			}
 			else

--- a/src/dc/inout.c
+++ b/src/dc/inout.c
@@ -193,7 +193,7 @@ readnumber(struct source *src, u_int base, u_int bscale)
 	bool dot = false, sign = false;
 
 	n = new_number();
-	bn_check(BN_zero(n->number));
+	BN_zero(n->number);
 
 	while ((ch = (*src->vtable->readchar)(src)) != EOF) {
 
@@ -231,8 +231,8 @@ readnumber(struct source *src, u_int base, u_int bscale)
 		base_n = BN_new();
 		exponent = BN_new();
 		divisor = new_number();
-		bn_check(BN_zero(base_n));
-		bn_check(BN_zero(exponent));
+		BN_zero(base_n);
+		BN_zero(exponent);
 
 		bn_check(BN_add_word(base_n, base));
 		bn_check(BN_add_word(exponent, iscale));


### PR DESCRIPTION
bc_zero has been guaranteed not to fail since 1.x, and in openssl 3.x it no longer returns a value at all