### PR TITLE
fix hexdump(1) output

### DIFF
--- a/patches/src/hexdump/display.c.patch
+++ b/patches/src/hexdump/display.c.patch
@@ -1,5 +1,5 @@
 --- hexdump/display.c.orig	2021-07-02 01:42:54.491313094 +0200
-+++ hexdump/display.c	2021-07-02 01:54:12.999774093 +0200
++++ hexdump/display.c	2022-01-10 04:26:05.404103677 +0100
 @@ -38,12 +38,10 @@ static char sccsid[] = "@(#)display.c	8.
  __FBSDID("$FreeBSD$");
  
@@ -14,6 +14,62 @@
  #include <ctype.h>
  #include <err.h>
  #include <errno.h>
+@@ -107,7 +105,7 @@ display(void)
+ 		for (pr = endfu->nextpr; pr; pr = pr->nextpr)
+ 			switch(pr->flags) {
+ 			case F_ADDRESS:
+-				(void)printf(pr->fmt, (quad_t)eaddress);
++				(void)printf(pr->fmt, (long long)eaddress);
+ 				break;
+ 			case F_TEXT:
+ 				(void)printf("%s", pr->fmt);
+@@ -131,7 +129,7 @@ print(PR *pr, u_char *bp)
+ 
+ 	switch(pr->flags) {
+ 	case F_ADDRESS:
+-		(void)printf(pr->fmt, (quad_t)address);
++		(void)printf(pr->fmt, (long long)address);
+ 		break;
+ 	case F_BPAD:
+ 		(void)printf(pr->fmt, "");
+@@ -164,15 +162,15 @@ print(PR *pr, u_char *bp)
+ 	case F_INT:
+ 		switch(pr->bcnt) {
+ 		case 1:
+-			(void)printf(pr->fmt, (quad_t)(signed char)*bp);
++			(void)printf(pr->fmt, (long long)(signed char)*bp);
+ 			break;
+ 		case 2:
+ 			bcopy(bp, &s2, sizeof(s2));
+-			(void)printf(pr->fmt, (quad_t)s2);
++			(void)printf(pr->fmt, (long long)s2);
+ 			break;
+ 		case 4:
+ 			bcopy(bp, &s4, sizeof(s4));
+-			(void)printf(pr->fmt, (quad_t)s4);
++			(void)printf(pr->fmt, (long long)s4);
+ 			break;
+ 		case 8:
+ 			bcopy(bp, &s8, sizeof(s8));
+@@ -195,15 +193,15 @@ print(PR *pr, u_char *bp)
+ 	case F_UINT:
+ 		switch(pr->bcnt) {
+ 		case 1:
+-			(void)printf(pr->fmt, (u_quad_t)*bp);
++			(void)printf(pr->fmt, (unsigned long long)*bp);
+ 			break;
+ 		case 2:
+ 			bcopy(bp, &u2, sizeof(u2));
+-			(void)printf(pr->fmt, (u_quad_t)u2);
++			(void)printf(pr->fmt, (unsigned long long)u2);
+ 			break;
+ 		case 4:
+ 			bcopy(bp, &u4, sizeof(u4));
+-			(void)printf(pr->fmt, (u_quad_t)u4);
++			(void)printf(pr->fmt, (unsigned long long)u4);
+ 			break;
+ 		case 8:
+ 			bcopy(bp, &u8, sizeof(u8));
 @@ -364,18 +362,6 @@ next(char **argv)
  			statok = 0;
  		}

--- a/patches/src/hexdump/parse.c.patch
+++ b/patches/src/hexdump/parse.c.patch
@@ -1,5 +1,5 @@
 --- hexdump/parse.c.orig	2021-07-02 01:55:39.887054656 +0200
-+++ hexdump/parse.c	2021-07-02 02:08:17.173697600 +0200
++++ hexdump/parse.c	2022-01-10 04:28:28.585413869 +0100
 @@ -52,7 +52,7 @@ FU *endfu;					/* format at end-of-data
  void
  addfile(const char *name)
@@ -37,16 +37,32 @@
  	int prec;
  
  	/* figure out the data block size needed for each format unit */
-@@ -210,7 +211,7 @@ rewrite(FS *fs)
+@@ -210,8 +211,8 @@ rewrite(FS *fs)
  	enum { NOTOKAY, USEBCNT, USEPREC } sokay;
  	PR *pr, **nextpr;
  	FU *fu;
 -	unsigned char *p1, *p2, *fmtp;
+-	char savech, cs[3];
 +	char *p1, *p2, *fmtp;
- 	char savech, cs[3];
++	char savech, cs[4];
  	int nconv, prec;
  
-@@ -334,6 +335,7 @@ isint:				cs[2] = '\0';
+ 	prec = 0;
+@@ -290,9 +291,10 @@ rewrite(FS *fs)
+ 				goto isint;
+ 			case 'o': case 'u': case 'x': case 'X':
+ 				pr->flags = F_UINT;
+-isint:				cs[2] = '\0';
+-				cs[1] = cs[0];
+-				cs[0] = 'q';
++isint:				cs[3] = '\0';
++				cs[2] = cs[0];
++				cs[1] = 'l';
++				cs[0] = 'l';
+ 				switch(fu->bcnt) {
+ 				case 0: case 4:
+ 					pr->bcnt = 4;
+@@ -334,6 +336,7 @@ isint:				cs[2] = '\0';
  				switch(sokay) {
  				case NOTOKAY:
  					badsfmt();
@@ -54,3 +70,17 @@
  				case USEBCNT:
  					pr->bcnt = fu->bcnt;
  					break;
+@@ -354,9 +357,10 @@ isint:				cs[2] = '\0';
+ 					++p2;
+ 					switch(p1[2]) {
+ 					case 'd': case 'o': case'x':
+-						cs[0] = 'q';
+-						cs[1] = p1[2];
+-						cs[2] = '\0';
++						cs[0] = 'l';
++						cs[1] = 'l';
++						cs[2] = p1[2];
++						cs[3] = '\0';
+ 						break;
+ 					default:
+ 						p1[3] = '\0';

--- a/src/hexdump/display.c
+++ b/src/hexdump/display.c
@@ -105,7 +105,7 @@ display(void)
 		for (pr = endfu->nextpr; pr; pr = pr->nextpr)
 			switch(pr->flags) {
 			case F_ADDRESS:
-				(void)printf(pr->fmt, (quad_t)eaddress);
+				(void)printf(pr->fmt, (long long)eaddress);
 				break;
 			case F_TEXT:
 				(void)printf("%s", pr->fmt);
@@ -129,7 +129,7 @@ print(PR *pr, u_char *bp)
 
 	switch(pr->flags) {
 	case F_ADDRESS:
-		(void)printf(pr->fmt, (quad_t)address);
+		(void)printf(pr->fmt, (long long)address);
 		break;
 	case F_BPAD:
 		(void)printf(pr->fmt, "");
@@ -162,15 +162,15 @@ print(PR *pr, u_char *bp)
 	case F_INT:
 		switch(pr->bcnt) {
 		case 1:
-			(void)printf(pr->fmt, (quad_t)(signed char)*bp);
+			(void)printf(pr->fmt, (long long)(signed char)*bp);
 			break;
 		case 2:
 			bcopy(bp, &s2, sizeof(s2));
-			(void)printf(pr->fmt, (quad_t)s2);
+			(void)printf(pr->fmt, (long long)s2);
 			break;
 		case 4:
 			bcopy(bp, &s4, sizeof(s4));
-			(void)printf(pr->fmt, (quad_t)s4);
+			(void)printf(pr->fmt, (long long)s4);
 			break;
 		case 8:
 			bcopy(bp, &s8, sizeof(s8));
@@ -193,15 +193,15 @@ print(PR *pr, u_char *bp)
 	case F_UINT:
 		switch(pr->bcnt) {
 		case 1:
-			(void)printf(pr->fmt, (u_quad_t)*bp);
+			(void)printf(pr->fmt, (unsigned long long)*bp);
 			break;
 		case 2:
 			bcopy(bp, &u2, sizeof(u2));
-			(void)printf(pr->fmt, (u_quad_t)u2);
+			(void)printf(pr->fmt, (unsigned long long)u2);
 			break;
 		case 4:
 			bcopy(bp, &u4, sizeof(u4));
-			(void)printf(pr->fmt, (u_quad_t)u4);
+			(void)printf(pr->fmt, (unsigned long long)u4);
 			break;
 		case 8:
 			bcopy(bp, &u8, sizeof(u8));

--- a/src/hexdump/parse.c
+++ b/src/hexdump/parse.c
@@ -212,7 +212,7 @@ rewrite(FS *fs)
 	PR *pr, **nextpr;
 	FU *fu;
 	char *p1, *p2, *fmtp;
-	char savech, cs[3];
+	char savech, cs[4];
 	int nconv, prec;
 
 	prec = 0;
@@ -291,9 +291,10 @@ rewrite(FS *fs)
 				goto isint;
 			case 'o': case 'u': case 'x': case 'X':
 				pr->flags = F_UINT;
-isint:				cs[2] = '\0';
-				cs[1] = cs[0];
-				cs[0] = 'q';
+isint:				cs[3] = '\0';
+				cs[2] = cs[0];
+				cs[1] = 'l';
+				cs[0] = 'l';
 				switch(fu->bcnt) {
 				case 0: case 4:
 					pr->bcnt = 4;
@@ -356,9 +357,10 @@ isint:				cs[2] = '\0';
 					++p2;
 					switch(p1[2]) {
 					case 'd': case 'o': case'x':
-						cs[0] = 'q';
-						cs[1] = p1[2];
-						cs[2] = '\0';
+						cs[0] = 'l';
+						cs[1] = 'l';
+						cs[2] = p1[2];
+						cs[3] = '\0';
 						break;
 					default:
 						p1[3] = '\0';


### PR DESCRIPTION
The 'q' length modifier is not a part of standard C, and at least on musl it results in nothing being printed. Replace with the
safe 'll' and modify the (u_)quad_t types to use `long long` or `unsigned long long` as necessary.