### PR TITLE
Removed libxo dependency (df and wc)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -101,7 +101,7 @@ libcrypto = dependency('libcrypto', required : get_option('libcrypto'))
 libm = cc.find_library('m', required : true)
 
 # df(1) needs libxo
-libxo = dependency('libxo', required : true)
+#libxo = dependency('libxo', required : true)
 
 # needed by a few utils; provided by glibc, but not by e.g. musl
 

--- a/src/df/df.c
+++ b/src/df/df.c
@@ -62,7 +62,6 @@ __FBSDID("$FreeBSD$");
 #include <string.h>
 #include <sysexits.h>
 #include <unistd.h>
-#include <libxo/xo.h>
 #include <assert.h>
 #include <mntent.h>
 
@@ -114,7 +113,7 @@ static int	  checkvfsname(const char *vfsname, const char **vfslist, int skip);
 static int	  checkvfsselected(char *);
 static int	  int64width(int64_t);
 static void       prthuman(const struct mntinfo *, int64_t);
-static void	  prthumanval(const char *, int64_t);
+static void	  prthumanval(int64_t);
 static intmax_t	  fsbtoblk(int64_t, uint64_t, u_long);
 static void       prtstat(struct mntinfo *, struct maxwidths *);
 static size_t     regetmntinfo(struct mntinfo **, long);
@@ -155,11 +154,6 @@ main(int argc, char *argv[])
 	memset(&maxwidths, 0, sizeof(maxwidths));
 	memset(&totalbuf, 0, sizeof(totalbuf));
 	totalbuf.f_bsize = DEV_BSIZE;
-
-	argc = xo_parse_args(argc, argv);
-	if (argc < 0)
-		exit(1);
-
 	while ((ch = getopt_long(argc, argv, "+abcgHhiklmnPt:T,", long_options,
 	    NULL)) != -1)
 		switch (ch) {
@@ -217,7 +211,7 @@ main(int argc, char *argv[])
 			break;
 		case 't':
 			if (vfslist_t != NULL)
-				xo_errx(1, "only one -t option may be specified");
+				errx(1, "only one -t option may be specified");
 			vfslist_t = makevfslist(optarg, &skipvfs_t);
 			break;
 		case 'T':
@@ -237,9 +231,6 @@ main(int argc, char *argv[])
 	mntsize = getmntinfo(&mntbuf);
 	mntsize = regetmntinfo(&mntbuf, mntsize);
 
-	xo_open_container("storage-system-information");
-	xo_open_list("filesystem");
-
 	/* unselect all filesystems if an explicit list is given */
 	if (*argv) {
 		for (i = 0; i < mntsize; i++) {
@@ -251,14 +242,14 @@ main(int argc, char *argv[])
 	for (; *argv; argv++) {
 		if (stat(*argv, &stbuf) < 0) {
 			if ((mntpt = getmntpt(&mntbuf, mntsize, *argv)) == NULL) {
-				xo_warn("%s", *argv);
+				warn("%s", *argv);
 				rv = 1;
 				continue;
 			}
 		} else if (S_ISCHR(stbuf.st_mode)) {
 			mntpt = getmntpt(&mntbuf, mntsize, *argv);
 			if (mntpt == NULL) {
-				xo_warnx("%s: not mounted", *argv);
+				warnx("%s: not mounted", *argv);
 				rv = 1;
 				continue;
 			}
@@ -293,14 +284,8 @@ main(int argc, char *argv[])
 	for (i = 0; i < mntsize; i++)
 		if ((aflag || (mntbuf[i].f_blocks > 0)) && mntbuf[i].f_selected)
 			prtstat(&mntbuf[i], &maxwidths);
-
-	xo_close_list("filesystem");
-
 	if (cflag)
 		prtstat(&totalbuf, &maxwidths);
-
-	xo_close_container("storage-system-information");
-	xo_finish();
 	freemntinfo(mntbuf, mntsize);
 	exit(rv);
 }
@@ -422,7 +407,7 @@ regetmntinfo(struct mntinfo **mntbufp, long mntsize)
 		if (nflag || error < 0)
 			if (i != j) {
 				if (error < 0)
-					xo_warnx("%s stats possibly stale",
+					warnx("%s stats possibly stale",
 					    mntbuf[i].f_mntonname);
 
 				free(mntbuf[j].f_fstypename);
@@ -451,13 +436,13 @@ static void
 prthuman(const struct mntinfo *sfsp, int64_t used)
 {
 
-	prthumanval("  {:blocks/%6s}", sfsp->f_blocks * sfsp->f_bsize);
-	prthumanval("  {:used/%6s}", used * sfsp->f_bsize);
-	prthumanval("  {:available/%6s}", sfsp->f_bavail * sfsp->f_bsize);
+	prthumanval(sfsp->f_blocks * sfsp->f_bsize);
+	prthumanval(used * sfsp->f_bsize);
+	prthumanval(sfsp->f_bavail * sfsp->f_bsize);
 }
 
 static void
-prthumanval(const char *fmt, int64_t bytes)
+prthumanval(int64_t bytes)
 {
 	char buf[6];
 	int flags;
@@ -469,15 +454,14 @@ prthumanval(const char *fmt, int64_t bytes)
 	humanize_number(buf, sizeof(buf) - (bytes < 0 ? 0 : 1),
 	    bytes, "", HN_AUTOSCALE, flags);
 
-	xo_attr("value", "%lld", (long long) bytes);
-	xo_emit(fmt, buf);
+    (void)printf("  %6s", buf);
 }
 
 /*
  * Print an inode count in "human-readable" format.
  */
 static void
-prthumanvalinode(const char *fmt, int64_t bytes)
+prthumanvalinode(int64_t bytes)
 {
 	char buf[6];
 	int flags;
@@ -487,8 +471,7 @@ prthumanvalinode(const char *fmt, int64_t bytes)
 	humanize_number(buf, sizeof(buf) - (bytes < 0 ? 0 : 1),
 	    bytes, "", HN_AUTOSCALE, flags);
 
-	xo_attr("value", "%lld", (long long) bytes);
-	xo_emit(fmt, buf);
+    (void)printf("  %5s", buf);
 }
 
 /*
@@ -533,10 +516,10 @@ prtstat(struct mntinfo *sfsp, struct maxwidths *mwp)
 		mwp->used = imax(mwp->used, (int)strlen("Used"));
 		mwp->avail = imax(mwp->avail, (int)strlen("Avail"));
 
-		xo_emit("{T:/%-*s}", mwp->mntfrom, "Filesystem");
+		(void)printf("%-*s", mwp->mntfrom, "Filesystem");
 		if (Tflag)
-			xo_emit("  {T:/%-*s}", mwp->fstype, "Type");
-		xo_emit(" {T:/%*s} {T:/%*s} {T:/%*s} {T:Capacity}",
+			(void)printf("  {T:/%-*s}", mwp->fstype, "Type");
+		(void)printf(" %*s %*s %*s Capacity",
 			mwp->total, header,
 			mwp->used, "Used", mwp->avail, "Avail");
 		if (iflag) {
@@ -544,66 +527,62 @@ prtstat(struct mntinfo *sfsp, struct maxwidths *mwp)
 			    (int)strlen("  iused"));
 			mwp->ifree = imax(hflag ? 0 : mwp->ifree,
 			    (int)strlen("ifree"));
-			xo_emit(" {T:/%*s} {T:/%*s} {T:\%iused}",
+			(void)printf(" %*s %*s %%iused",
 			    mwp->iused - 2, "iused", mwp->ifree, "ifree");
 		}
-		xo_emit("  {T:Mounted on}\n");
+		(void)printf("  Mounted on\n");
 	}
 
-	xo_open_instance("filesystem");
 	/* Check for 0 block size.  Can this happen? */
 	if (sfsp->f_bsize == 0) {
-		xo_warnx ("File system %s does not have a block size, assuming 512.",
+		warnx ("File system %s does not have a block size, assuming 512.",
 		    sfsp->f_mntonname);
 		sfsp->f_bsize = 512;
 	}
-	xo_emit("{tk:name/%-*s}", mwp->mntfrom, sfsp->f_mntfromname);
+	(void)printf("%-*s", mwp->mntfrom, sfsp->f_mntfromname);
 	if (Tflag)
-		xo_emit("  {:type/%-*s}", mwp->fstype, sfsp->f_fstypename);
+		(void)printf("  %-*s", mwp->fstype, sfsp->f_fstypename);
 	used = sfsp->f_blocks - sfsp->f_bfree;
 	availblks = sfsp->f_bavail + used;
 	if (hflag) {
 		prthuman(sfsp, used);
 	} else {
 		if (thousands)
-		    format = " {t:total-blocks/%*j'd} {t:used-blocks/%*j'd} "
-			"{t:available-blocks/%*j'd}";
+		    format = " %*j'd %*j'd %*j'd";
 		else
-		    format = " {t:total-blocks/%*jd} {t:used-blocks/%*jd} "
-			"{t:available-blocks/%*jd}";
-		xo_emit(format,
+		    format = " %*jd %*jd %*jd";
+		(void)printf(format,
 		    mwp->total, fsbtoblk(sfsp->f_blocks,
 		    sfsp->f_bsize, blocksize),
 		    mwp->used, fsbtoblk(used, sfsp->f_bsize, blocksize),
 		    mwp->avail, fsbtoblk(sfsp->f_bavail,
 		    sfsp->f_bsize, blocksize));
 	}
-	xo_emit("   {:used-percent/%5.0f}{U:%%}",
+	(void)printf("   %5.0f%%",
 	    availblks == 0 ? 100.0 : (double)used / (double)availblks * 100.0);
 	if (iflag) {
 		inodes = sfsp->f_files;
 		used = inodes - sfsp->f_ffree;
 		if (hflag) {
-			xo_emit("  ");
-			prthumanvalinode(" {:inodes-used/%5s}", used);
-			prthumanvalinode(" {:inodes-free/%5s}", sfsp->f_ffree);
+			(void)printf("  ");
+			prthumanvalinode(used);
+			prthumanvalinode(sfsp->f_ffree);
 		} else {
 			if (thousands)
-			    format = " {:inodes-used/%*j'd} {:inodes-free/%*j'd}";
+		    format = " %*j'd %*j'd";
 			else
-			    format = " {:inodes-used/%*jd} {:inodes-free/%*jd}";
-			xo_emit(format, mwp->iused, (intmax_t)used,
+		    format = " %*jd %*jd";
+			(void)printf(format, mwp->iused, (intmax_t)used,
 			    mwp->ifree, (intmax_t)sfsp->f_ffree);
 		}
-		xo_emit(" {:inodes-used-percent/%4.0f}{U:%%} ",
+		(void)printf(" %4.0f%% ",
 			inodes == 0 ? 100.0 :
 			(double)used / (double)inodes * 100.0);
 	} else
-		xo_emit("  ");
+		(void)printf("  ");
 	if (strcmp(sfsp->f_mntfromname, "total") != 0)
-		xo_emit("{:mounted-on}", sfsp->f_mntonname);
-	xo_emit("\n");
-	xo_close_instance("filesystem");
+		(void)printf("  %s", sfsp->f_mntonname);
+	(void)printf("\n");
 }
 
 static void
@@ -670,7 +649,7 @@ static void
 usage(void)
 {
 
-	xo_error(
+	(void)fprintf(stderr,
 "usage: df [-b | -g | -H | -h | -k | -m | -P] [-acilnT] [-t type] [-,]\n"
 "          [file | filesystem ...]\n");
 	exit(EX_USAGE);

--- a/src/df/meson.build
+++ b/src/df/meson.build
@@ -2,7 +2,7 @@ df_prog = executable(
     'df',
     [ 'df.c' ],
     include_directories : inc,
-    dependencies : [ libxo ],
+    dependencies : [ ],
     link_with : [ libcompat ],
     install : true,
 )

--- a/src/diff/diffreg.c
+++ b/src/diff/diffreg.c
@@ -278,11 +278,11 @@ diffreg(char *file1, char *file2, int flags, int capsicum)
 		padding = tabsize - (hw % tabsize);
 		if ((flags & D_EXPANDTABS) != 0 || (padding % tabsize == 0))
 			padding = MIN_PAD;
-	
+
 		hw = (width >> 1) -
 		    ((padding == MIN_PAD) ? (padding << 1) : padding) - 1;
 	}
-	
+
 
 	if (flags & D_IGNORECASE)
 		chrtran = cup2low;
@@ -1312,7 +1312,7 @@ fetch(long *f, int a, int b, FILE *lb, int ch, int oldfile, int flags)
 			if (c == '\t') {
 				if (flags & D_EXPANDTABS) {
 					newcol = ((col/tabsize)+1)*tabsize;
-					do {	
+					do {
 						if (diff_format == D_SIDEBYSIDE)
 							j++;
 						printf(" ");

--- a/src/diff/meson.build
+++ b/src/diff/meson.build
@@ -6,10 +6,10 @@ diff_prog = executable(
       'xmalloc.c',
       'pr.c',
     ],
+    include_directories : inc,
+    link_with : [ libcompat ],
     install : true,
 )
 
 install_man('diff.1')
 
-#    include_directories : inc,
-#    link_with : [ libcompat ],

--- a/src/wc/meson.build
+++ b/src/wc/meson.build
@@ -2,7 +2,7 @@ wc_prog = executable(
     'wc',
     [ 'wc.c' ],
     include_directories : [ inc, ],
-    dependencies : [ libxo ],
+    dependencies : [ ],
     install : true,
 )
 

--- a/src/wc/wc.c
+++ b/src/wc/wc.c
@@ -61,14 +61,12 @@ __FBSDID("$FreeBSD$");
 #include <unistd.h>
 #include <wchar.h>
 #include <wctype.h>
-#include <libxo/xo.h>
 
 #include "compat.h"
 
 static uintmax_t tlinect, twordct, tcharct, tlongline;
 static int doline, doword, dochar, domulti, dolongline;
 static volatile sig_atomic_t siginfo;
-static xo_handle_t *stderr_handle;
 
 static void	show_cnt(const char *file, uintmax_t linect, uintmax_t wordct,
 		    uintmax_t charct, uintmax_t llct);
@@ -97,9 +95,6 @@ main(int argc, char *argv[])
 
 	(void) setlocale(LC_CTYPE, "");
 
-	argc = xo_parse_args(argc, argv);
-	if (argc < 0)
-		return (argc);
 
 	while ((ch = getopt(argc, argv, "clmwL")) != -1)
 		switch((char)ch) {
@@ -133,37 +128,21 @@ main(int argc, char *argv[])
 	if (doline + doword + dochar + domulti + dolongline == 0)
 		doline = doword = dochar = 1;
 
-	stderr_handle = xo_create_to_file(stderr, XO_STYLE_TEXT, 0);
-	xo_open_container("wc");
-	xo_open_list("file");
-
 	errors = 0;
 	total = 0;
 	if (!*argv) {
-	 	xo_open_instance("file");
 		if (cnt((char *)NULL) != 0)
 			++errors;
-	 	xo_close_instance("file");
 	} else {
 		do {
-	 		xo_open_instance("file");
 			if (cnt(*argv) != 0)
 				++errors;
-	 		xo_close_instance("file");
 			++total;
 		} while(*++argv);
 	}
 
-	xo_close_list("file");
-
-	if (total > 1) {
-		xo_open_container("total");
+	if (total > 1)
 		show_cnt("total", tlinect, twordct, tcharct, tlongline);
-		xo_close_container("total");
-	}
-
-	xo_close_container("wc");
-	xo_finish();
 	exit(errors == 0 ? 0 : 1);
 }
 
@@ -171,27 +150,27 @@ static void
 show_cnt(const char *file, uintmax_t linect, uintmax_t wordct,
     uintmax_t charct, uintmax_t llct)
 {
-	xo_handle_t *xop;
+    FILE *out;
 
 	if (!siginfo)
-		xop = NULL;
+		out = stdout;
 	else {
-		xop = stderr_handle;
+		out = stderr;
 		siginfo = 0;
 	}
 
 	if (doline)
-		xo_emit_h(xop, " {:lines/%7ju/%ju}", linect);
+		(void)fprintf(out, " %7ju", linect);
 	if (doword)
-		xo_emit_h(xop, " {:words/%7ju/%ju}", wordct);
+		(void)fprintf(out, " %7ju", wordct);
 	if (dochar || domulti)
-		xo_emit_h(xop, " {:characters/%7ju/%ju}", charct);
+		(void)fprintf(out, " %7ju", charct);
 	if (dolongline)
-		xo_emit_h(xop, " {:long-lines/%7ju/%ju}", llct);
+		(void)fprintf(out, " %7ju", llct);
 	if (file != NULL)
-		xo_emit_h(xop, " {:filename/%s}\n", file);
+		(void)fprintf(out, " %s\n", file);
 	else
-		xo_emit_h(xop, "\n");
+		(void)fprintf(out, "\n");
 }
 
 static int
@@ -211,7 +190,7 @@ cnt(const char *file)
 	if (file == NULL)
 		fd = STDIN_FILENO;
 	else if ((fd = open(file, O_RDONLY, 0)) < 0) {
-		xo_warn("%s: open", file);
+		warn("%s: open", file);
 		return (1);
 	}
 	if (doword || (domulti && MB_CUR_MAX != 1))
@@ -222,7 +201,7 @@ cnt(const char *file)
 	 */
 	if (doline == 0 && dolongline == 0) {
 		if (fstat(fd, &sb)) {
-			xo_warn("%s: fstat", file != NULL ? file : "stdin");
+			warn("%s: fstat", file != NULL ? file : "stdin");
 			(void)close(fd);
 			return (1);
 		}
@@ -243,7 +222,7 @@ cnt(const char *file)
 	 */
 	while ((len = read(fd, buf, MAXBSIZE))) {
 		if (len == -1) {
-			xo_warn("%s: read", file != NULL ? file : "stdin");
+			warn("%s: read", file != NULL ? file : "stdin");
 			(void)close(fd);
 			return (1);
 		}
@@ -278,7 +257,7 @@ word:	gotsp = 1;
 	memset(&mbs, 0, sizeof(mbs));
 	while ((len = read(fd, buf, MAXBSIZE)) != 0) {
 		if (len == -1) {
-			xo_warn("%s: read", file != NULL ? file : "stdin");
+			warn("%s: read", file != NULL ? file : "stdin");
 			(void)close(fd);
 			return (1);
 		}
@@ -293,7 +272,7 @@ word:	gotsp = 1;
 			    (size_t)-1) {
 				if (!warned) {
 					errno = EILSEQ;
-					xo_warn("%s",
+					warn("%s",
 					    file != NULL ? file : "stdin");
 					warned = 1;
 				}
@@ -326,7 +305,7 @@ word:	gotsp = 1;
 	reset_siginfo();
 	if (domulti && MB_CUR_MAX > 1)
 		if (mbrtowc(NULL, NULL, 0, &mbs) == (size_t)-1 && !warned)
-			xo_warn("%s", file != NULL ? file : "stdin");
+			warn("%s", file != NULL ? file : "stdin");
 	if (doline)
 		tlinect += linect;
 	if (doword)
@@ -343,6 +322,6 @@ word:	gotsp = 1;
 static void
 usage(void)
 {
-	xo_error("usage: wc [-Lclmw] [file ...]\n");
+	(void)fprintf(stderr, "usage: wc [-Lclmw] [file ...]\n");
 	exit(1);
 }


### PR DESCRIPTION
This Pull Request removes the libxo dependency from ``wc`` and ``df``, allowing them both to build without a dependency most users will not have. This actually maintains the FreeBSD codebase, as historically these were the implementations before patches were introduced alongside the libxo library (https://github.com/Juniper/libxo/tree/a46bb3585fb7cbbd4add46e8af99763531bfda4c/patches).

The main motivation behind this change was mostly to revert the libxo dependency, as explained above. I would have just dealt with the dependency, but it is not in the Gentoo repos and I couldn't get it to build.
